### PR TITLE
Fix defi.conf parsing

### DIFF
--- a/masternode_health/monitor.py
+++ b/masternode_health/monitor.py
@@ -36,7 +36,7 @@ class NodeMonitor:
             ignore = False
 
             for line in lines:
-                var = line.split('=')
+                var = line.split('=', 1)
 
                 if len(var) == 1 and 'test' in var[0]:
                     ignore = True


### PR DESCRIPTION
Proper splitting for INI style files. In my case the password did include an equal sign "=" so the line.split('=') failed because it did split the password.